### PR TITLE
Added nurdism/neko

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - [rviscarra/webrtc-remote-screen](https://github.com/rviscarra/webrtc-remote-screen)
 - [rviscarra/webrtc-speech-to-text](https://github.com/rviscarra/webrtc-speech-to-text)
 - [~tslocum/harmony](https://git.sr.ht/~tslocum/harmony)
+- [nurdism/neko](https://github.com/nurdism/neko)
 
 ## DataChannel
 


### PR DESCRIPTION
Neko is a virtual browser that runs in docker, using webrtc to capture and send desktop a/v to a web client and the web client will forward keyboard and mouse input to the desktop/browser.
