### PR TITLE
add Mux to companies

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@
 - [LiveKit](https://livekit.io)
 - [Mosaic Networks](https://github.com/mosaicnetworks/babble)
 - [Mutagen](https://mutagen.io/)
+- [Mux](https://www.mux.com/)
 - [Muxable](https://muxable.com/)
 - [Neverinstall](https://neverinstall.com)
 - [Piepacker](https://piepacker.com)


### PR DESCRIPTION
#### Description

Adds Mux as a listed company that uses Pion.

