### PR TITLE
Add 1mb-dev/natcheck to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,8 @@
 
 ## Tools
 
+- [1mb-dev/natcheck](https://github.com/1mb-dev/natcheck) - NAT type diagnosis CLI built on pion/stun. Reports a WebRTC direct-P2P forecast.
+
 <details>
 <summary> Old Tools </summary>
 


### PR DESCRIPTION
Adds [natcheck](https://github.com/1mb-dev/natcheck) — a STUN-based NAT type diagnosis CLI built on `pion/stun/v3`. Latest release: v0.1.1.